### PR TITLE
Jacobian.py: switch from cp to sync to prevent downloads when data already present

### DIFF
--- a/jacobian.py
+++ b/jacobian.py
@@ -661,7 +661,7 @@ def download_TROPOMI(startdate, enddate):
     end_day = end_str[8:10]
 
     DATA_DOWNLOAD_SCRIPT='./auto_generated_download_script.sh'
-    cmd_prefix = "aws s3 cp --recursive "
+    cmd_prefix = "aws s3 sync "
     remote_root = "s3://meeo-s5p/"
     # access number of days in each month easily
     month_days = [31,[28,29],31,30,31,30,31,31,30,31,30,31]


### PR DESCRIPTION
@djvaron Using `sync` instead of `cp --recursive` should only download the tropomi data if it is not already present in the `Sat_datadir` directory.